### PR TITLE
Add order_by parameter in directory listing (set to -modified_at when paste from clipboard)

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -282,7 +282,10 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             show_result_count = False
 
         folder_qs = folder_qs.order_by('name')
-        file_qs = file_qs.order_by('name')
+        order_by = request.GET.get('order_by', None)
+        if order_by is not None:
+            order_by = order_by.split(',')
+            file_qs = file_qs.order_by(*order_by)
 
         folder_children = []
         folder_files = []
@@ -311,7 +314,10 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             }
         except:
             permissions = {}
-        folder_files.sort()
+
+        if order_by is None:
+            folder_files.sort()
+        
         items = folder_children + folder_files
         items_permissions = [(item, {'change': self.has_change_permission(request, item)}) for item in items]
         paginator = Paginator(items_permissions, FILER_PAGINATE_BY)

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -44,6 +44,7 @@ from filer.utils.filer_easy_thumbnails import FilerActionThumbnailer
 from filer.thumbnail_processors import normalize_subject_location
 from django.conf import settings as django_settings
 import os
+import re
 import itertools
 
 
@@ -288,8 +289,9 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         if order_by is not None:
             order_by = order_by.split(',')
             order_by = [field for field in order_by
-                        if field.replace('-', '') in self.order_by_file_fields]
-            file_qs = file_qs.order_by(*order_by)
+                        if re.sub(r'^-', '', field) in self.order_by_file_fields]
+            if len(order_by) > 0:
+                file_qs = file_qs.order_by(*order_by)
 
         folder_children = []
         folder_files = []
@@ -319,7 +321,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         except:
             permissions = {}
 
-        if order_by is None:
+        if order_by is None or len(order_by) == 0:
             folder_files.sort()
         
         items = folder_children + folder_files

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -68,6 +68,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                'copy_files_and_folders', 'resize_images', 'rename_files']
 
     directory_listing_template = 'admin/filer/folder/directory_listing.html'
+    order_by_file_fields = ('_file_size', 'original_filename', 'name', 'owner',
+                            'uploaded_at', 'modified_at')
 
     def get_form(self, request, obj=None, **kwargs):
         """
@@ -285,6 +287,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         order_by = request.GET.get('order_by', None)
         if order_by is not None:
             order_by = order_by.split(',')
+            order_by = [field for field in order_by
+                        if field.replace('-', '') in self.order_by_file_fields]
             file_qs = file_qs.order_by(*order_by)
 
         folder_children = []

--- a/filer/views.py
+++ b/filer/views.py
@@ -145,9 +145,9 @@ def paste_clipboard_to_folder(request):
             tools.discard_clipboard(clipboard)
         else:
             raise PermissionDenied
-    return HttpResponseRedirect('%s%s%s' % (
+    return HttpResponseRedirect('%s?order_by=-modified_at%s%s' % (
                                 request.REQUEST.get('redirect_to', ''),
-                                popup_param(request),
+                                popup_param(request, separator='&'),
                                 selectfolder_param(request)))
 
 


### PR DESCRIPTION
Files will be sorted according to order_by parameter if exists. If this parameter is not
set, then files are sorted as before (by its str representation, its name or original_filename). 
This parameter can be set to a list of fields separated by commas in order to sort by more than one field.

After pasting a file from the clipboard, the directory listing is called with this parameter
set to -modified_at. Therefore, the pasted element could be more easily selected.