### PR TITLE
generic JS usable when a row is duplicated when file is a part of a ManyToMany

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -84,7 +84,10 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
         return obj
 
     class Media:
-        js = (filer_settings.FILER_STATICMEDIA_PREFIX + 'js/popup_handling.js',)
+        js = (
+            filer_settings.FILER_STATICMEDIA_PREFIX + 'js/popup_handling.js',
+            filer_settings.FILER_STATICMEDIA_PREFIX + 'js/widget.js',
+        )
 
 
 class AdminFileFormField(forms.ModelChoiceField):

--- a/filer/static/filer/js/popup_handling.js
+++ b/filer/static/filer/js/popup_handling.js
@@ -22,4 +22,4 @@
 		document.getElementById(id_name).innerHTML = chosenName;
 		win.close();
 	};
-})(jQuery);
+})(django.jQuery);

--- a/filer/static/filer/js/widget.js
+++ b/filer/static/filer/js/widget.js
@@ -17,4 +17,4 @@
         //if this file is included multiple time, we ensure that filer_clear is attached only once.
         $(document).off('click.filer', '.filerFile .filerClearer', filer_clear).on('click.filer', '.filerFile .filerClearer', filer_clear);
     });
-})(jQuery);
+})(django.jQuery);

--- a/filer/static/filer/js/widget.js
+++ b/filer/static/filer/js/widget.js
@@ -1,0 +1,20 @@
+(function($) {
+    var filer_clear = function(e){
+        var clearer = $(this),
+            hidden_input = clearer.closest('.filerFile').find('input.vForeignKeyRawIdAdminField'),
+            base_id = '#'+hidden_input.attr('id'),
+            thumbnail = $(base_id+'_thumbnail_img'),
+            description = $(base_id+'_description_txt'),
+            static_prefix = clearer.attr('src').replace('admin/img/icon_deletelink.gif', 'filer/');
+        clearer.hide();
+        hidden_input.removeAttr("value");
+        thumbnail.attr("src", static_prefix+"icons/nofile_48x48.png");
+        description.html("");
+    }
+
+    $(document).ready(function(){
+        $('.filerFile .vForeignKeyRawIdAdminField').attr('type', 'hidden');
+        //if this file is included multiple time, we ensure that filer_clear is attached only once.
+        $(document).off('click.filer', '.filerFile .filerClearer', filer_clear).on('click.filer', '.filerFile .filerClearer', filer_clear);
+    });
+})(jQuery);

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -19,18 +19,6 @@
 <br />
 {{ hidden_input }}
 <script type="text/javascript" id="{{id}}_javascript">
-    django.jQuery('#{{id}}').attr('type', 'hidden').attr('data-filer', 1);
-    django.jQuery(document).on('click', '.filerFile .filerClearer', function(e){
-        var clearer = django.jQuery(this),
-            hidden_input = clearer.closest('.filerFile').find('input[data-filer=1]'),
-            base_id = '#'+hidden_input.attr('id'),
-            thumbnail = django.jQuery(base_id+'_thumbnail_img'),
-            description = django.jQuery(base_id+'_description_txt');
-        clearer.hide();
-        hidden_input.removeAttr("value");
-        thumbnail.attr("src", "{{ filer_static_prefix }}icons/nofile_48x48.png");
-        description.html("");
-    });
     django.jQuery(document).ready(function(){
         var plus = django.jQuery("#add_{{ id }}");
         if (plus.length){

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -1,4 +1,5 @@
 {% load i18n filer_admin_tags %}{% spaceless %}
+<span class="filerFile">
 {% if object %}
 	{% if object.icons.32 %}
 		<a href="{{ object.url }}" target="_blank"><img id="{{ thumb_id }}" src="{{ object.icons.48 }}" alt="{{ object.label }}" /></a>
@@ -14,22 +15,30 @@
 <a href="{{ lookup_url }}" class="related-lookup" id="lookup_id_{{ lookup_name }}" title="{% trans 'Lookup' %}" onclick="return showRelatedObjectLookupPopup(this);">
 	<img src="{% admin_icon_base %}icon_searchbox.png" width="16" height="16" alt="{% trans 'Lookup' %}" />
 </a>
-<img id="{{ clear_id }}" src="{% admin_icon_base %}icon_deletelink.gif" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %} />
+<img id="{{ clear_id }}" class="filerClearer" src="{% admin_icon_base %}icon_deletelink.gif" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %} />
 <br />
 {{ hidden_input }}
-<script type="text/javascript">
-	django.jQuery("#{{ id }}").hide();
-	django.jQuery("#{{ clear_id }}").click(function(){
-		django.jQuery("#{{ id }}").removeAttr("value");
-		django.jQuery("#{{ thumb_id }}").attr("src", "{{ filer_static_prefix }}icons/nofile_48x48.png");
-		django.jQuery("#{{ span_id }}").html("");
-		django.jQuery("#{{ clear_id }}").hide();
-	});
-	django.jQuery(document).ready(function(){
-		var plus = django.jQuery("#add_{{ id }}");
-		if (plus.length){
-			plus.remove();
-		}
-	});
+<script type="text/javascript" id="{{id}}_javascript">
+    django.jQuery('#{{id}}').attr('type', 'hidden').attr('data-filer', 1);
+    django.jQuery(document).on('click', '.filerFile .filerClearer', function(e){
+        var clearer = django.jQuery(this),
+            hidden_input = clearer.closest('.filerFile').find('input[data-filer=1]'),
+            base_id = '#'+hidden_input.attr('id'),
+            thumbnail = django.jQuery(base_id+'_thumbnail_img'),
+            description = django.jQuery(base_id+'_description_txt');
+        clearer.hide();
+        hidden_input.removeAttr("value");
+        thumbnail.attr("src", "{{ filer_static_prefix }}icons/nofile_48x48.png");
+        description.html("");
+    });
+    django.jQuery(document).ready(function(){
+        var plus = django.jQuery("#add_{{ id }}");
+        if (plus.length){
+            plus.remove();
+        }
+        {# Delete this javascript once loaded to avoid the "add new" link duplicates it #}
+        django.jQuery('#{{id}}_javascript').remove();
+    });
 </script>
+</span>
 {% endspaceless %}


### PR DESCRIPTION
How to reproduce :

Use a FilerField in a ManyToMany, and use admin's inline to manage it in the admin form.
When "add new row" is clicked, the "clear" image is displayed and not functionnal.

This is because the old javascript is for the current ID, so new lines, with != IDs, couldn't work. This bug fix use classes and the jQuery(document).on function to watch event on newly created lines.