### PR TITLE
Skip new migration if table already exists

### DIFF
--- a/filer/migrations_django/0002_image.py
+++ b/filer/migrations_django/0002_image.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import models, migrations, connection
 from filer.settings import FILER_IMAGE_MODEL
 
 
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = []
-    if not FILER_IMAGE_MODEL:
+    if not FILER_IMAGE_MODEL and 'filer_image' not in connection.introspection.table_names():
         operations.append(
             migrations.CreateModel(
                 name='Image',


### PR DESCRIPTION
Skip the new 0002_image django 1.7 migration if table already exists for compatibility with previous migration structure