### PR TITLE
global name 'logger' is not defined

### DIFF
--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -8,6 +8,9 @@ except ImportError:
     except ImportError:
         raise ImportError("The Python Imaging Library was not found.")
 
+import logging
+logger = logging.getLogger(__name__)
+
 from django.db import models
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
when IOError('encoder jpeg not available',)
-->  logger.error('Error while generating thumbnail: %s',e)
line 139 (now 141)