### PR TITLE
dismiss_popup.html should be rendered with a RequestContext

### DIFF
--- a/filer/views.py
+++ b/filer/views.py
@@ -108,7 +108,8 @@ def make_folder(request, folder_id=None):
                 new_folder.parent = folder
                 new_folder.owner = request.user
                 new_folder.save()
-                return render_to_response('admin/filer/dismiss_popup.html')
+                return render_to_response('admin/filer/dismiss_popup.html',
+                                          context_instance=RequestContext(request))
     else:
         new_folder_form = NewFolderForm()
     return render_to_response('admin/filer/folder/new_folder_form.html', {


### PR DESCRIPTION
It inherits from admin/base_site.html, which can request certain context variables. Without a request context, it won't have what it needs.