### PR TITLE
Updated get_admin_url_path to work with django 1.8 deprecation 

### DIFF
--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -1,6 +1,10 @@
 #-*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import django
+import hashlib
+import os
+
 from django.core import urlresolvers
 from django.conf import settings
 from django.core.files.base import ContentFile
@@ -12,8 +16,6 @@ from filer import settings as filer_settings
 from filer.models.foldermodels import Folder
 from filer.utils.compatibility import python_2_unicode_compatible
 from polymorphic import PolymorphicModel, PolymorphicManager
-import hashlib
-import os
 
 
 class FileManager(PolymorphicManager):
@@ -216,9 +218,13 @@ class File(PolymorphicModel, mixins.IconsMixin):
         return text
 
     def get_admin_url_path(self):
+        if django.VERSION < (1, 7):
+            module_name = self._meta.module_name
+        else:
+            module_name = self._meta.model_name
         return urlresolvers.reverse(
             'admin:%s_%s_change' % (self._meta.app_label,
-                                    self._meta.module_name,),
+                                    module_name,),
             args=(self.pk,)
         )
 


### PR DESCRIPTION
I ran across this issue when using this code with Django 1.8. I copied this solution: https://github.com/lukaszb/django-guardian/pull/287

Sorry, but I did not run tests yet. I was having an issue getting them to work. 

Please advise any changes.