### PR TITLE
Added scope-wrapper function to use django.jQuery

### DIFF
--- a/filer/static/filer/js/jquery.cookie.js
+++ b/filer/static/filer/js/jquery.cookie.js
@@ -1,3 +1,4 @@
+(function(jQuery) {
 /**
  * Cookie plugin
  *
@@ -95,3 +96,4 @@ jQuery.cookie = function(name, value, options) {
         return cookieValue;
     }
 };
+})(django.jQuery);

--- a/filer/templates/admin/filer/tools/upload_button_js.html
+++ b/filer/templates/admin/filer/tools/upload_button_js.html
@@ -3,6 +3,7 @@
 
 <script type="text/javascript">
 //<![CDATA[
+(function($) {
 $(function() {
     var uploader = new qq.FileUploaderBasic({
         action: '{% url 'admin:filer-ajax_upload' %}',
@@ -37,5 +38,6 @@ $(function() {
         }
     });
 });
+})(django.jQuery);
 //]]>
 </script>


### PR DESCRIPTION
This makes filer work in admin modules that does not define $ or jQuery in the global scope.
(All the other scripts already use django.jQuery)