### PR TITLE
add migration for recent django-polymorphic

### DIFF
--- a/filer/migrations/0002_auto_20150606_2003.py
+++ b/filer/migrations/0002_auto_20150606_2003.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('filer', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='file',
+            name='polymorphic_ctype',
+            field=models.ForeignKey(related_name='polymorphic_filer.file_set+', editable=False, to='contenttypes.ContentType', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'Django>=1.4',
         'easy-thumbnails>=1.0',
         'django-mptt>=0.6',
-        'django_polymorphic>=0.2',
+        'django_polymorphic>=0.7',
         'Unidecode>=0.04',
     ),
     include_package_data=True,


### PR DESCRIPTION
django-polymorphic==0.7 changed the reverse relation for the polymorphic
content-type. Django 1.7 migrations detects this as a change (although
nothing changes at database level).
South does not detect this as a change and does not need a new
migration.

This commit introduced the necessary change: https://github.com/chrisglass/django_polymorphic/compare/v0.6.1...v0.7#diff-22a782d7dcedbbbe6a4efdadd17dadc9R59