### PR TITLE
swap jQuery with $, as jQuery seems undefined

### DIFF
--- a/filer/static/filer/js/focal_point.js
+++ b/filer/static/filer/js/focal_point.js
@@ -77,7 +77,7 @@ $(function(){
 		add(x, y);
 		image_loaded = true
 	}
-	jQuery(document).ready(function() {
+	$(document).ready(function() {
 		$('#image_container img').load(image_init);
 		// If image has not been loaded after 250ms after pageload,
 		// assume it's allready loaded and try initializing.


### PR DESCRIPTION
this works for me. if jQuery is used, I get a 

````
focal_point.js:80 Uncaught TypeError: undefined is not a function
````
