### PR TITLE
Fix unsupported backend error when using s3 in django-storages

### DIFF
--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -80,7 +80,7 @@ class BaseImage(File):
             return self._exif_cache
         else:
             if self.file:
-                self._exif_cache = get_exif_for_file(self.file.path)
+                self._exif_cache = get_exif_for_file(self.file)
             else:
                 self._exif_cache = {}
         return self._exif_cache

--- a/filer/utils/pil_exif.py
+++ b/filer/utils/pil_exif.py
@@ -9,6 +9,8 @@ except ImportError:
     except ImportError:
         raise ImportError("The Python Imaging Library was not found.")
 
+from django.core.files.storage import default_storage as storage
+
 
 def get_exif(im):
     try:
@@ -23,7 +25,7 @@ def get_exif(im):
 
 
 def get_exif_for_file(file_obj):
-    im = Image.open(file_obj, 'r')
+    im = Image.open(storage.open(file_obj.name), 'r')
     return get_exif(im)
 
 


### PR DESCRIPTION
the storages backend doesn't implement path() as it should be, but filer requires that.