### PR TITLE
Remove unused 'thumbnail' template tags to avoid conflicts - fixes #560

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@
 * Martin Brochhaus <mbrochh@gmail.com> https://github.com/mbrochh
 * Ioan Alexandru Cucu https://github.com/kux
 * Tim Graham https://github.com/timgraham
+* Philippe O. Wagner https://github.com/philippeowagner

--- a/filer/templates/admin/filer/tools/clipboard/clipboard.html
+++ b/filer/templates/admin/filer/tools/clipboard/clipboard.html
@@ -1,4 +1,4 @@
-{% load thumbnail i18n %}
+{% load i18n %}
 {% load url from future %}
 
 {% for clipboard in user.filer_clipboards.all %}

--- a/filer/templates/admin/filer/tools/clipboard/clipboard_item_rows.html
+++ b/filer/templates/admin/filer/tools/clipboard/clipboard_item_rows.html
@@ -1,4 +1,4 @@
-{% load thumbnail i18n %}{% if items %}
+{% load i18n %}{% if items %}
 {% for generic_item in items %}{% with generic_item as item %}
         <tr class="clipboardItem">
             <td class="thumbnail"><img src="{{ item.icons.32 }}" alt="{{ item.default_alt_text }}" /></td>


### PR DESCRIPTION
BTW: There is a feature branch ready to merge django-smart-load-tag into filer on my side. 

Fix #560