### PR TITLE
FolderAdmin uses base admin context in views

### DIFF
--- a/.travis_setup
+++ b/.travis_setup
@@ -1,2 +1,5 @@
 #!/bin/bash
 pip install djangocms-helper==0.8.1 unidecode $DJANGO 'Pillow<2.6' $EASY_THUMBNAILS django-polymorphic django-mptt python-coveralls coverage south
+if [[ "$TRAVIS_PYTHON_VERSION" == 2.6 ]]; then
+    pip install unittest2
+fi

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -37,7 +37,8 @@ from filer.admin.tools import (userperms_for_request,
                                check_folder_edit_permissions,
                                check_files_edit_permissions,
                                check_files_read_permissions,
-                               check_folder_read_permissions)
+                               check_folder_read_permissions,
+                               admin_each_context)
 from filer.models import (Folder, FolderRoot, UnfiledImages, File, tools,
                           ImagesWithMissingData, FolderPermission, Image)
 from filer.settings import FILER_STATICMEDIA_PREFIX, FILER_PAGINATE_BY
@@ -378,40 +379,40 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             paginated_items = paginator.page(1)
         except EmptyPage:
             paginated_items = paginator.page(paginator.num_pages)
-        return render(
-            request,
-            self.directory_listing_template,
-            {
-                'folder': folder,
-                'clipboard_files': File.objects.filter(
-                    in_clipboards__clipboarditem__clipboard__user=request.user
-                    ).distinct(),
-                'paginator': paginator,
-                'paginated_items': paginated_items,  # [(item, item_perms), ]
-                'permissions': permissions,
-                'permstest': userperms_for_request(folder, request),
-                'current_url': request.path,
-                'title': 'Directory listing for %s' % folder.name,
-                'search_string': ' '.join(search_terms),
-                'q': urlquote(q),
-                'show_result_count': show_result_count,
-                'limit_search_to_folder': limit_search_to_folder,
-                'is_popup': popup_status(request),
-                'select_folder': selectfolder_status(request),
-                # needed in the admin/base.html template for logout links
-                'root_path': reverse('admin:index'),
-                'action_form': action_form,
-                'actions_on_top': self.actions_on_top,
-                'actions_on_bottom': self.actions_on_bottom,
-                'actions_selection_counter': self.actions_selection_counter,
-                'selection_note': _('0 of %(cnt)s selected') % {'cnt': len(paginated_items.object_list)},
-                'selection_note_all': selection_note_all % {'total_count': paginator.count},
-                'media': self.media,
-                'enable_permissions': settings.FILER_ENABLE_PERMISSIONS,
-                'can_make_folder': request.user.is_superuser or \
-                        (folder.is_root and settings.FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS) or \
-                        permissions.get("has_add_children_permission"),
+
+        context = admin_each_context(self.admin_site, request)
+        context.update({
+            'folder': folder,
+            'clipboard_files': File.objects.filter(
+                in_clipboards__clipboarditem__clipboard__user=request.user
+            ).distinct(),
+            'paginator': paginator,
+            'paginated_items': paginated_items,  # [(item, item_perms), ]
+            'permissions': permissions,
+            'permstest': userperms_for_request(folder, request),
+            'current_url': request.path,
+            'title': 'Directory listing for %s' % folder.name,
+            'search_string': ' '.join(search_terms),
+            'q': urlquote(q),
+            'show_result_count': show_result_count,
+            'limit_search_to_folder': limit_search_to_folder,
+            'is_popup': popup_status(request),
+            'select_folder': selectfolder_status(request),
+            # needed in the admin/base.html template for logout links
+            'root_path': reverse('admin:index'),
+            'action_form': action_form,
+            'actions_on_top': self.actions_on_top,
+            'actions_on_bottom': self.actions_on_bottom,
+            'actions_selection_counter': self.actions_selection_counter,
+            'selection_note': _('0 of %(cnt)s selected') % {'cnt': len(paginated_items.object_list)},
+            'selection_note_all': selection_note_all % {'total_count': paginator.count},
+            'media': self.media,
+            'enable_permissions': settings.FILER_ENABLE_PERMISSIONS,
+            'can_make_folder': request.user.is_superuser or \
+            (folder.is_root and settings.FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS) or \
+            permissions.get("has_add_children_permission"),
         })
+        return render(request, self.directory_listing_template, context)
 
     def filter_folder(self, qs, terms=[]):
         for term in terms:
@@ -699,7 +700,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         else:
             title = _("Are you sure?")
 
-        context = {
+        context = admin_each_context(self.admin_site, request)
+        context.update({
             "title": title,
             "instance": current_folder,
             "breadcrumbs_action": _("Delete files and/or folders"),
@@ -714,7 +716,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             "root_path": reverse('admin:index'),
             "app_label": app_label,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
-        }
+        })
 
         # Display the destination folder selection page
         return render(request, "admin/filer/delete_selected_files_confirmation.html", context)
@@ -845,7 +847,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                 })
             return None
 
-        context = {
+        context = admin_each_context(self.admin_site, request)
+        context.update({
             "title": _("Move files and/or folders"),
             "instance": current_folder,
             "breadcrumbs_action": _("Move files and/or folders"),
@@ -858,7 +861,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             "root_path": reverse('admin:index'),
             "app_label": app_label,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
-        }
+        })
 
         # Display the destination folder selection page
         return render(request, "admin/filer/folder/choose_move_destination.html", context)
@@ -927,7 +930,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         else:
             form = RenameFilesForm()
 
-        context = {
+        context = admin_each_context(self.admin_site, request)
+        context.update({
             "title": _("Rename files"),
             "instance": current_folder,
             "breadcrumbs_action": _("Rename files"),
@@ -940,7 +944,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             "root_path": reverse('admin:index'),
             "app_label": app_label,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
-        }
+        })
 
         # Display the rename format selection page
         return render(request, "admin/filer/folder/choose_rename_format.html", context)
@@ -1054,7 +1058,9 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                 selected_destination_folder = current_folder.pk
             else:
                 selected_destination_folder = 0
-        context = {
+
+        context = admin_each_context(self.admin_site, request)
+        context.update({
             "title": _("Copy files and/or folders"),
             "instance": current_folder,
             "breadcrumbs_action": _("Copy files and/or folders"),
@@ -1069,7 +1075,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             "root_path": reverse('admin:index'),
             "app_label": app_label,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
-        }
+        })
 
         # Display the destination folder selection page
         return render(request, "admin/filer/folder/choose_copy_destination.html", context)
@@ -1175,7 +1181,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         else:
             form = ResizeImagesForm()
 
-        context = {
+        context = admin_each_context(self.admin_site, request)
+        context.update({
             "title": _("Resize images"),
             "instance": current_folder,
             "breadcrumbs_action": _("Resize images"),
@@ -1189,7 +1196,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             "root_path": reverse('admin:index'),
             "app_label": app_label,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
-        }
+        })
 
         # Display the resize options page
         return render(request, "admin/filer/folder/choose_images_resize_options.html", context)

--- a/filer/admin/tools.py
+++ b/filer/admin/tools.py
@@ -1,5 +1,18 @@
 #-*- coding: utf-8 -*-
+
+import django
 from django.core.exceptions import PermissionDenied
+
+
+if django.get_version() > '1.8':
+    def admin_each_context(admin_site, request):
+        return admin_site.each_context(request)
+elif django.get_version() > '1.7':
+    def admin_each_context(admin_site, request):
+        return admin_site.each_context()
+else:
+    def admin_each_context(admin_site, request):
+        return {}
 
 
 def check_files_edit_permissions(request, files):

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -1,5 +1,7 @@
 #-*- coding: utf-8 -*-
 import os
+from unittest import skipIf
+import django
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 import django.core.files
@@ -125,6 +127,19 @@ class FilerFolderAdminUrlsTests(TestCase):
         self.assertEqual(response.status_code, 302)
         folder = Folder.objects.get(pk=folder.pk)
         self.assertEqual(folder.owner.pk, another_superuser.pk)
+
+
+    @skipIf(django.get_version() < '1.7',
+            'admin context not supported in django < 1.7')
+    def test_folder_admin_uses_admin_context(self):
+        folder = Folder.objects.create(name='foo')
+        url = reverse('admin:filer-directory_listing', kwargs={
+            'folder_id': folder.id})
+        response = self.client.get(url)
+        self.assertTrue('site_header' in response.context)
+        self.assertTrue('site_title' in response.context)
+
+
 
 
 class FilerImageAdminUrlsTests(TestCase):
@@ -265,7 +280,7 @@ class FilerBulkOperationsTests(BulkOperationsMixin, TestCase):
           |   |-bar
           |
           |--bar
-        
+
         and try to move the owter bar in foo. This has to fail since it would result
         in two folders with the same name and parent.
         """

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -1,6 +1,11 @@
 #-*- coding: utf-8 -*-
 import os
-from unittest import skipIf
+
+try:
+    from unittest import skipIf
+except ImportError: # for python 2.6
+    from unittest2 import skipIf
+
 import django
 from django.test import TestCase
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
Views in admin site use a context which includes properties like
"site_head" and "site_url". This properties are used by base admin
templates.
Previously, FolderAdmin was creating a new context in his views
functions, not including default properties.
Now, FolderAdmin starts from the base context of every admin view.
This uses function each_context which is available in django>=1.7, so
the new behaviour is only from that version upwards.