### PR TITLE
Added checkerboard tiles as background to thumbnails. Fix for issue #562

### DIFF
--- a/filer/static/filer/css/admin_style.css
+++ b/filer/static/filer/css/admin_style.css
@@ -3,6 +3,16 @@
 #image_container { position: relative; } 
 #image_container img, #image_container svg { margin: 0px; position: absolute; top: 0; left: 0;}
 
+/* Tile pattern as background for transparent images: */
+.transpTiling {
+    /* light tiles */
+    background-image: url(data:image/gif;base64,R0lGODlhCAAIAKECAOPj4/z8/P///////yH5BAEKAAIALAAAAAAIAAgAAAINhBEZh8q6DoTPSWvoKQA7);
+    outline: 1px solid #E3E3E3;
+}
+.transpTiling:hover {
+    /* dark tiles */
+    background-image: url(data:image/gif;base64,R0lGODlhCAAIAKECAEFBQXR0dP///////yH5BAEKAAIALAAAAAAIAAgAAAINhBEZh8q6DoTPSWvoKQA7);
+}
 
 /* the directory listing */
 table thead th.thumbHeader {

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -35,7 +35,7 @@
             <tr class="{% cycle rowcolors %}">
                 <td>{% if is_popup and not select_folder %}<a class="insertlink insertlinkButton" href="" onclick="opener.dismissRelatedImageLookupPopup(window, {{ file.id|unlocalize }}, '{{ file.icons.48|escapejs }}', '{{ file.label|escapejs }}'); return false;" title="{% trans "Select this file" %}">&nbsp;</a>{% else %}{% if action_form and not is_popup %}<input type="checkbox" class="action-select" value="file-{{ item.pk }}" name="_selected_action" />{% endif %}{% endif %}</td>
                 <!-- FileIcon -->
-                <td>{% if item_perms.change %}<a href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">{% endif %}<img src="{% if file.icons.48 %}{{ file.icons.48 }}{% else %}{% filer_staticmedia_prefix %}icons/missingfile_48x48.png{% endif %}" alt="{{ file.default_alt_text }}" />{% if item_perms.change %}</a>{% endif %}</td>
+                <td class="transpTiling">{% if item_perms.change %}<a href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">{% endif %}<img src="{% if file.icons.48 %}{{ file.icons.48 }}{% else %}{% filer_staticmedia_prefix %}icons/missingfile_48x48.png{% endif %}" alt="{{ file.default_alt_text }}" />{% if item_perms.change %}</a>{% endif %}</td>
                 <!-- Filename/Dimensions -->
                 <td>
                     {% if item_perms.change %}

--- a/filer/templates/admin/filer/image/change_form.html
+++ b/filer/templates/admin/filer/image/change_form.html
@@ -14,7 +14,7 @@
 
 {% block file_sidebar %}
 <div id="navcontainer">
-    <div id="image_container">
+    <div id="image_container" class="transpTiling">
         <img src="{{ original.thumbnails.admin_sidebar_preview }}" alt="{{ original.label }}" rel="{{ adminform.form.sidebar_image_ratio }}" />
         <div id="paper">&nbsp;</div>
     </div>


### PR DESCRIPTION
Thumbnails in the directory table and the preview image now has a light checkerboard pattern background (that turns dark on mouseover) to make both light and dark transparent images easier to see.

Uses two small gif's embedded in the css using data urls so that it doesn't add additional http requests.