### PR TITLE
[Feature/FIX] FolderAdmin.search_fields now is used

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -61,7 +61,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
     exclude = ('parent',)
     list_per_page = 20
     list_filter = ('owner',)
-    search_fields = ['name', 'files__name']
+    search_fields = ['name__icontains', ]
     raw_id_fields = ('owner',)
     save_as = True  # see ImageAdmin
     actions = ['move_to_clipboard', 'files_set_public', 'files_set_private',
@@ -414,7 +414,9 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
 
     def filter_folder(self, qs, terms=[]):
         for term in terms:
-            filters = Q(name__icontains=term)
+            filters = Q()
+            for filter_ in self.search_fields:
+                filters |= Q(**{filter_: term})
             for filter_ in self.get_owner_filter_lookups():
                 filters |= Q(**{filter_: term})
             qs = qs.filter(filters)

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -61,7 +61,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
     exclude = ('parent',)
     list_per_page = 20
     list_filter = ('owner',)
-    search_fields = ['name__icontains', ]
+    search_fields = ['name', 'files__name']
     raw_id_fields = ('owner',)
     save_as = True  # see ImageAdmin
     actions = ['move_to_clipboard', 'files_set_public', 'files_set_private',
@@ -413,10 +413,21 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         }, context_instance=RequestContext(request))
 
     def filter_folder(self, qs, terms=[]):
+        # Source: https://github.com/django/django/blob/1.7.1/django/contrib/admin/options.py#L939-L947
+        def construct_search(field_name):
+            if field_name.startswith('^'):
+                return "%s__istartswith" % field_name[1:]
+            elif field_name.startswith('='):
+                return "%s__iexact" % field_name[1:]
+            elif field_name.startswith('@'):
+                return "%s__search" % field_name[1:]
+            else:
+                return "%s__icontains" % field_name
+
         for term in terms:
             filters = Q()
             for filter_ in self.search_fields:
-                filters |= Q(**{filter_: term})
+                filters |= Q(**{construct_search(filter_): term})
             for filter_ in self.get_owner_filter_lookups():
                 filters |= Q(**{filter_: term})
             qs = qs.filter(filters)


### PR DESCRIPTION
FolderAdmin is ignoring FolderAdmin.search_fields (see [FolderAdmin.filter_folder](https://github.com/stefanfoulis/django-filer/blob/develop/filer/admin/folderadmin.py#L421-L427) and [FolderAdmin](https://github.com/stefanfoulis/django-filer/blob/develop/filer/admin/folderadmin.py#L60-L67))

It would be great to use ``FolderAdmin.search_fields``, so one can just extend ``FolderAdmin´´ to change the search behavior as described in [Django's docs](https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields) . E.g.:
```python
class MyFolderAdmin(FolderAdmin):
    search_fields = ['=filed1', '^field2']

admin.site.unregister(Folder)
admin.site.register(Folder, MyFolderAdmin)
``` 

So I did it. :)


I also believe that ``FolderAdmin.owner_search_fields`` could use the same logic. However as it uses a wee different rule, I rather make it a different feature/pull request.