### PR TITLE
Fix django comparison

### DIFF
--- a/filer/admin/tools.py
+++ b/filer/admin/tools.py
@@ -1,18 +1,19 @@
 #-*- coding: utf-8 -*-
 
-import django
 from django.core.exceptions import PermissionDenied
 
+from filer.utils.compatibility import DJANGO_1_7, DJANGO_1_6
 
-if django.get_version() > '1.8':
+
+if DJANGO_1_6:
     def admin_each_context(admin_site, request):
-        return admin_site.each_context(request)
-elif django.get_version() > '1.7':
+        return {}
+elif DJANGO_1_7:
     def admin_each_context(admin_site, request):
         return admin_site.each_context()
 else:
     def admin_each_context(admin_site, request):
-        return {}
+        return admin_site.each_context(request)
 
 
 def check_files_edit_permissions(request, files):

--- a/filer/utils/compatibility.py
+++ b/filer/utils/compatibility.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from distutils.version import LooseVersion
 import sys
 
 import django
@@ -16,11 +15,11 @@ except ImportError:
         return Truncator(s).words(num, truncate=truncate)
     truncate_words = allow_lazy(truncate_words, six.text_type)
 
-DJANGO_1_4 = LooseVersion(django.get_version()) < LooseVersion('1.5')
-DJANGO_1_5 = LooseVersion(django.get_version()) < LooseVersion('1.6')
-DJANGO_1_6 = LooseVersion(django.get_version()) < LooseVersion('1.7')
-DJANGO_1_7 = LooseVersion(django.get_version()) < LooseVersion('1.8')
-DJANGO_1_8 = LooseVersion(django.get_version()) < LooseVersion('1.9')
+DJANGO_1_4 = django.VERSION < (1, 5)
+DJANGO_1_5 = django.VERSION < (1, 6)
+DJANGO_1_6 = django.VERSION < (1, 7)
+DJANGO_1_7 = django.VERSION < (1, 8)
+DJANGO_1_8 = django.VERSION < (1, 9)
 
 
 if not six.PY3:


### PR DESCRIPTION
  * If you installed Django==1.8.0, django.get_version() > '1.8' was
    False
  * If you would to install Django==1.10, django.get_version() > '1.8'
    would be False
  * Strings are not meant to be compared like numbers