### PR TITLE
Avoid nested forms by inserting the clipboard after the changelist form.

### DIFF
--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -104,6 +104,7 @@
         {% include "admin/filer/folder/directory_table.html" %}
         {% if action_form and actions_on_bottom and paginator.count and not select_folder and not is_popup %}{% filer_actions %}{% endif %}
         </form>
+        {% include "admin/filer/tools/clipboard/clipboard.html" %}
     </div>
 </div>
 

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -91,4 +91,3 @@
         {% endif %}
     </p>
 </div>
-{% include "admin/filer/tools/clipboard/clipboard.html" %}


### PR DESCRIPTION
Since https://github.com/stefanfoulis/django-filer/commit/f58cb6ade060560b6a8ac75484b719effcc27b20 the folder clipboard gets inserted directly into the changelist and thus there are nested forms which is not allowed and not supported (at least here my latest chrome is failing hard by simply not showing the `paste clipboard` form)

Rendering the clipboard after the changelist-form get's closed doesn't change visuals (imho) but fixes nested forms.