### PR TITLE
django.utils.importlib deprecated since django 1.7

### DIFF
--- a/filer/utils/loader.py
+++ b/filer/utils/loader.py
@@ -9,7 +9,7 @@ local changes:
 
 """
 from django.utils import six
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def load_object(import_path):


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib
django.utils.dictconfig and django.utils.importlib were copies of respectively logging.config and importlib provided for Python versions prior to 2.7. They have been deprecated.