### PR TITLE
adds hotfix for django 1.8

### DIFF
--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}{% spaceless %}
+{% load i18n filer_admin_tags staticfiles %}{% spaceless %}
 <span class="filerFile">
 {% if object %}
 	{% if object.icons.32 %}
@@ -12,9 +12,7 @@
 	<img id="{{ thumb_id }}" src="{% static "filer/icons/nofile_48x48.png" %}" class="quiet" alt="{% trans 'no file selected' %}" />
 	&nbsp;<span id="{{ span_id }}"></span>
 {% endif %}
-<a href="{{ lookup_url }}" class="related-lookup" id="lookup_id_{{ lookup_name }}" title="{% trans 'Lookup' %}" onclick="return showRelatedObjectLookupPopup(this);">
-    <img src="{% static 'admin/img/icon_searchbox.png' %}" width="16" height="16" alt="{% trans 'Lookup' %}" />
-</a>
+{% render_filer_lookup_button %}
 <img id="{{ clear_id }}" class="filerClearer" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %} />
 <br />
 {{ hidden_input }}

--- a/filer/templates/admin/filer/widgets/admin_folder.html
+++ b/filer/templates/admin/filer/widgets/admin_folder.html
@@ -1,12 +1,10 @@
-{% load i18n staticfiles %}{% spaceless %}
+{% load i18n filer_admin_tags staticfiles %}{% spaceless %}
 {% if object %}
     {% trans 'Folder' %}: <span id="{{ span_id }}">{{ object.pretty_logical_path }}</span>
 {% else %}
     {% trans 'Folder' %}: <span id="{{ span_id }}">{% trans 'none selected' %}</span>
 {% endif %}
-<a href="{{ lookup_url }}" class="related-lookup" id="lookup_id_{{ lookup_name }}" title="{% trans 'Lookup' %}" onclick="return showRelatedObjectLookupPopup(this);">
-    <img src="{% static 'admin/img/icon_searchbox.png' %}" width="16" height="16" alt="{% trans 'Lookup' %}" />
-</a>
+{% render_filer_lookup_button %}
 <img id="{{ clear_id }}" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %} />
 <br />
 {{ hidden_input }}

--- a/filer/templates/admin/filer/widgets/lookup.html
+++ b/filer/templates/admin/filer/widgets/lookup.html
@@ -1,0 +1,5 @@
+{% load i18n static %}
+
+<a href="{{ lookup_url }}" class="related-lookup" id="lookup_id_{{ lookup_name }}" title="{% trans 'Lookup' %}"{% if not IS_DJANGO_18 %} onclick="return showRelatedObjectLookupPopup(this);"{% endif %}>
+    <img src="{% static 'admin/img/icon_searchbox.png' %}" width="16" height="16" alt="{% trans 'Lookup' %}" />
+</a>

--- a/filer/templatetags/filer_admin_tags.py
+++ b/filer/templatetags/filer_admin_tags.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from distutils.version import LooseVersion
 
+import django
 from django.template import Library
+
 
 register = Library()
 
@@ -13,3 +16,11 @@ def filer_actions(context):
     context['action_index'] = context.get('action_index', -1) + 1
     return context
 filer_actions = register.inclusion_tag("admin/filer/actions.html", takes_context=True)(filer_actions)
+
+
+@register.inclusion_tag('admin/filer/widgets/lookup.html', takes_context=True)
+def render_filer_lookup_button(context):
+    version = LooseVersion(django.get_version())
+    is_18_and_up = version >= LooseVersion('1.8')
+    context['IS_DJANGO_18'] = is_18_and_up and  version < LooseVersion('1.9')
+    return context


### PR DESCRIPTION
Basically django 1.8 no longer needs the onclick() action so if rendered then it causes the list endpoint to be called twice and create a race condition in multi-thread environments.